### PR TITLE
Adding newreadme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ The documentation for the Cultural Thematic Path Ontology is realized using [WID
 The objective of this activity is to update the ontology during its life cycle, detecting bugs and new requirements.  
 
 ## Mappings
-In‑progress mappings to third‑party ontologies are available in the mapping directory and can be accessed via the persistent URI pattern:
+In‑progress mappings to third‑party ontologies are available in the `mapping` directory and can be accessed via the persistent URI pattern:
 
-https://w3id.org/ctp/mapping/[mappingName]
+`https://w3id.org/ctp/mapping/[mappingName]`
 
 For example:
 
-https://w3id.org/ctp/mapping/LinkedArt
+`https://w3id.org/ctp/mapping/LinkedArt`
 
 These mappings differ from alignments, as they are intended as conceptual correspondences rather than directly actionable alignments.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,14 @@ The documentation for the Cultural Thematic Path Ontology is realized using [WID
 
 ### Ontology maintenance ###
 The objective of this activity is to update the ontology during its life cycle, detecting bugs and new requirements.  
+
+## Mappings
+In‑progress mappings to third‑party ontologies are available in the mapping directory and can be accessed via the persistent URI pattern:
+
+https://w3id.org/ctp/mapping/[mappingName]
+
+For example:
+
+https://w3id.org/ctp/mapping/LinkedArt
+
+These mappings differ from alignments, as they are intended as conceptual correspondences rather than directly actionable alignments.

--- a/mapping/LinkedArt/README.md
+++ b/mapping/LinkedArt/README.md
@@ -1,0 +1,6 @@
+# Mapping of Linked Art Model 1.0 to CTP
+
+We provide the following documentation:
+
+- `MappingLinkedArtToCTPOntology.md`, which describes the correspondences from the Linked Art model to CTP  
+- `MappingSyntax.md`, which explains the syntax adopted in the mapping and is inspired by the syntax used in the Linked Art mappings (for example, <https://linked.art/cookbook/mappings/schema/>)


### PR DESCRIPTION
This PR 
- updates the main readme mentioning the new directory 'mapping';
- includes a readme.md associated with the linked art mapping.

Please take a look at the two readme content and merge.

In the meantime, the link to linked art mapping  'https://w3id.org/ctp/mapping/LinkedArt' has been approved and made operational. 